### PR TITLE
Accessibility issue: low contrast on select2 placeholder

### DIFF
--- a/select2.css
+++ b/select2.css
@@ -500,7 +500,7 @@ html[dir="rtl"] .select2-container-multi .select2-choices li
 }
 
 .select2-default {
-    color: #999 !important;
+    color: #555 !important;
 }
 
 .select2-container-multi .select2-choices .select2-search-choice {


### PR DESCRIPTION
Before: 
<img width="1422" alt="Screenshot 2024-07-09 at 14 02 12" src="https://github.com/colemanw/select2/assets/3735621/4f54ee81-d8e6-4603-8c9d-9fffa655f994">

After:
<img width="1188" alt="Screenshot 2024-07-09 at 14 24 24" src="https://github.com/colemanw/select2/assets/3735621/fcb7c196-38ab-4bec-a9d9-90f1a1b1feb3">

The two out of three contrast issues on placeholder are fixed as show in the screenshot above. The placeholder color is evaluated by https://accessibleweb.com/color-contrast-checker/ 