### PR TITLE
Fix Empty form label

### DIFF
--- a/select2.js
+++ b/select2.js
@@ -2004,6 +2004,9 @@ the specific language governing permissions and limitations under the Apache Lic
 
             this.focusser.attr("tabindex", this.elementTabIndex);
 
+            // use the accessible name in for the focusser label text if element label is not declared or empty
+            $("label[for='" + this.focusser.attr('id') + "']").text(originalTitle || elementLabel.text());
+
             // write label for search field using the label from the focusser element
             this.search.attr("id", this.focusser.attr('id') + '_search');
 


### PR DESCRIPTION
Before
-------
<img width="1410" alt="Screenshot 2024-07-15 at 16 38 04" src="https://github.com/user-attachments/assets/4db0f1f0-4f21-4975-8e30-69fb1095f6d7">




After
-----
![cred1](https://github.com/user-attachments/assets/d46b8ef2-ac7d-49de-902a-833602e49b19)

Technical details
------------------
This PR is about making element without label text accessible by having title attribute assign to it and later utilized by select2  code to use as a placeholder to fix the accessibly issue [Missing Form Label](https://equalizedigital.com/accessibility-checker/empty-missing-form-label/) 

Dependent PR - https://github.com/civicrm/civicrm-core/pull/30675 
Minified js included in this PR - https://github.com/colemanw/select2/pull/6 

